### PR TITLE
Ignore .Rplots.pdf

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -17,3 +17,4 @@
 ^cran-comments\.md$
 ^docs$
 ^pkgdown$
+^Rplots\.pdf$

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ tmp.md
 tmp_files
 .DS_Store
 docs
+Rplots.pdf


### PR DESCRIPTION
This PR ignores the .Rplots.pdf -- which seems to be an unintentional 
artifact of running examples.

It would be good to follow up with a PR that ensures .Rplots.pdf is not
generated in the first place. 
