### PR TITLE
Update package-level documentation with rOpenSci links

### DIFF
--- a/man/allodb-package.Rd
+++ b/man/allodb-package.Rd
@@ -12,9 +12,9 @@ Tool to standardize and simplify the tree biomass
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://forestgeo.github.io/allodb}
-  \item \url{https://github.com/forestgeo/allodb}
-  \item Report bugs at \url{https://github.com/forestgeo/allodb/issues}
+  \item \url{https://ropensci.github.io/allodb}
+  \item \url{https://github.com/ropensci/allodb}
+  \item Report bugs at \url{https://github.com/ropensci/allodb/issues}
 }
 
 }


### PR DESCRIPTION
Running devtools::document()﻿ updates the package-level
documentation because the repo URLs have changed -- 
they now point to rOpenSci.

