### PR TITLE
Fix rOpenSci docs url

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Authors@R:
 Description: Tool to standardize and simplify the tree biomass
     estimation process across globally distributed extratropical forests.
 License: GPL-3
-URL: https://ropensci.github.io/allodb, https://github.com/ropensci/allodb
+URL: https://docs.ropensci.org/allodb/, https://github.com/ropensci/allodb
 BugReports: https://github.com/ropensci/allodb/issues
 Depends: 
     R (>= 3.6.0)

--- a/man/allodb-package.Rd
+++ b/man/allodb-package.Rd
@@ -12,7 +12,7 @@ Tool to standardize and simplify the tree biomass
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://ropensci.github.io/allodb}
+  \item \url{https://docs.ropensci.org/allodb/}
   \item \url{https://github.com/ropensci/allodb}
   \item Report bugs at \url{https://github.com/ropensci/allodb/issues}
 }


### PR DESCRIPTION
Doesn't work:  https://ropensci.github.io/allodb
Works: https://docs.ropensci.org/allodb

In https://github.com/ropensci/software-review/issues/436#issuecomment-927619124 I see:

> In addition, in your DESCRIPTION file, include the docs link in the URL field alongside the link to the GitHub repository, e.g.: URL: https://docs.ropensci.org/foobar (website) https://github.com/ropensci/foobar

I note it refers to https://docs.ropensci.org/foobar not https://ropensci.github.io

--

FYI I did a similar change in the About section of the main GitHub page:

![image](https://user-images.githubusercontent.com/5856545/135452160-86d48a38-125e-4eed-9c89-3570e8914c90.png)
