### PR TITLE
Avoid spelling note in R CMD check

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: allodb
-Title: Tree Biomass Estimation at Extratropical Forest Plots
+Title: Tree Biomass Estimation at Extra-Tropical Forest Plots
 Version: 0.0.1
 Authors@R: 
     c(person(given = "Erika",
@@ -28,7 +28,7 @@ Authors@R:
              role = "rev",
              email = "jonas.stillhard@wsl.ch"))      
 Description: Tool to standardize and simplify the tree biomass
-    estimation process across globally distributed extratropical forests.
+    estimation process across globally distributed extra-tropical forests.
 License: GPL-3
 URL: https://docs.ropensci.org/allodb/, https://github.com/ropensci/allodb
 BugReports: https://github.com/ropensci/allodb/issues

--- a/man/allodb-package.Rd
+++ b/man/allodb-package.Rd
@@ -4,10 +4,9 @@
 \name{allodb-package}
 \alias{allodb}
 \alias{allodb-package}
-\title{allodb: Tree Biomass Estimation at Extratropical Forest Plots}
+\title{allodb: Tree Biomass Estimation at Extra-Tropical Forest Plots}
 \description{
-Tool to standardize and simplify the tree biomass
-    estimation process across globally distributed extratropical forests.
+Tool to standardize and simplify the tree biomass estimation process across globally distributed extra-tropical forests.
 }
 \seealso{
 Useful links:
@@ -19,12 +18,12 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Erika Gonzalez-Akre \email{GonzalezEB@si.edu} [copyright holder]
+\strong{Maintainer}: Erika Gonzalez-Akre \email{maurolepore@gmail.com} [copyright holder]
 
 Authors:
 \itemize{
   \item Camille Piponiot \email{camille.piponiot@gmail.com}
-  \item Mauro Lepore \email{maurolepore@gmail.com} (\href{https://orcid.org/0000-0002-1986-7988}{ORCID})
+  \item Mauro Lepore \email{FIXME@gmail.com} (\href{https://orcid.org/0000-0002-1986-7988}{ORCID})
   \item Kristina Anderson-Teixeira \email{TeixeiraK@si.edu}
 }
 


### PR DESCRIPTION
The word Extratropical gets picked up by the automated spellchecker
during R CMD check. This rises a note the will likely result in
R core team asking us to fix the spelling. Even if we argue for
leaving the word as it, it may take an extra round of review. To
increase the odds the package will be accepted as is I suggest
using extra-tropical instead. This applies only to DESCRIPTION and
likely we can change it back to extratropical after the fist release
and with no consequences.
