### PR TITLE
Support R 3.5

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -34,7 +34,6 @@ jobs:
           - {os: ubuntu-18.04,   r: 'oldrel-1'}
           - {os: ubuntu-18.04,   r: 'oldrel-2'}
           - {os: ubuntu-18.04,   r: 'oldrel-3'}
-          - {os: ubuntu-18.04,   r: 'oldrel-4'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,18 +1,14 @@
-# NOTE: This workflow is overkill for most R packages
-# check-standard.yaml is likely a better choice
-# usethis::use_github_action("check-standard") will install it.
+# Workflow derived from https://github.com/r-lib/actions/tree/master/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 #
-# For help debugging build failures open an issue on the RStudio community with the 'github-actions' tag.
-# https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
+# NOTE: This workflow is overkill for most R packages and
+# check-standard.yaml is likely a better choice.
+# usethis::use_github_action("check-standard") will install it.
 on:
   push:
-    branches:
-      - main
-      - master
+    branches: [main, master]
   pull_request:
-    branches:
-      - main
-      - master
+    branches: [main, master]
 
 name: R-CMD-check
 
@@ -27,67 +23,39 @@ jobs:
       matrix:
         config:
           - {os: macOS-latest,   r: 'release'}
+
           - {os: windows-latest, r: 'release'}
+          # Use 3.6 to trigger usage of RTools35
           - {os: windows-latest, r: '3.6'}
-          - {os: ubuntu-18.04,   r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest", http-user-agent: "R/4.1.0 (ubuntu-18.04) R (4.1.0 x86_64-pc-linux-gnu x86_64 linux-gnu) on GitHub Actions" }
-          - {os: ubuntu-18.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
-          - {os: ubuntu-18.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/bionic/latest"}
+
+          # Use older ubuntu to maximise backward compatibility
+          - {os: ubuntu-18.04,   r: 'devel', http-user-agent: 'release'}
+          - {os: ubuntu-18.04,   r: 'release'}
+          - {os: ubuntu-18.04,   r: 'oldrel-1'}
+          - {os: ubuntu-18.04,   r: 'oldrel-2'}
+          - {os: ubuntu-18.04,   r: 'oldrel-3'}
+          - {os: ubuntu-18.04,   r: 'oldrel-4'}
 
     env:
-      RSPM: ${{ matrix.config.rspm }}
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
 
     steps:
       - uses: actions/checkout@v2
 
+      - uses: r-lib/actions/setup-pandoc@v1
+
       - uses: r-lib/actions/setup-r@v1
-        id: install-r
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
 
-      - uses: r-lib/actions/setup-pandoc@v1
-
-      - name: Install pak and query dependencies
-        run: |
-          install.packages("pak", repos = "https://r-lib.github.io/p/pak/dev/")
-          saveRDS(pak::pkg_deps("local::.", dependencies = TRUE), ".github/r-depends.rds")
-        shell: Rscript {0}
-
-      - name: Cache R packages
-        uses: actions/cache@v2
+      - uses: r-lib/actions/setup-r-dependencies@v1
         with:
-          path: ${{ env.R_LIBS_USER }}
-          key: ${{ matrix.config.os }}-${{ steps.install-r.outputs.installed-r-version }}-1-${{ hashFiles('.github/r-depends.rds') }}
-          restore-keys: ${{ matrix.config.os }}-${{ steps.install-r.outputs.installed-r-version }}-1-
+          extra-packages: rcmdcheck
 
-      - name: Install system dependencies
-        if: runner.os == 'Linux'
-        run: |
-          pak::local_system_requirements(execute = TRUE)
-          pak::pkg_system_requirements("rcmdcheck", execute = TRUE)
-        shell: Rscript {0}
-
-      - name: Install dependencies
-        run: |
-          pak::local_install_dev_deps(upgrade = TRUE)
-          pak::pkg_install("rcmdcheck")
-        shell: Rscript {0}
-
-      - name: Session info
-        run: |
-          options(width = 100)
-          pkgs <- installed.packages()[, "Package"]
-          sessioninfo::session_info(pkgs, include_base = TRUE)
-        shell: Rscript {0}
-
-      - name: Check
-        env:
-          _R_CHECK_CRAN_INCOMING_: false
-        run: |
-          options(crayon.enabled = TRUE)
-          rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
-        shell: Rscript {0}
+      - uses: r-lib/actions/check-r-package@v1
 
       - name: Show testthat output
         if: always()
@@ -98,5 +66,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@main
         with:
-          name: ${{ matrix.config.os }}-r${{ matrix.config.r }}-results
+          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ License: GPL-3
 URL: https://docs.ropensci.org/allodb/, https://github.com/ropensci/allodb
 BugReports: https://github.com/ropensci/allodb/issues
 Depends: 
-    R (>= 3.5), 
+    R (>= 3.5) 
 Imports:
     data.table (>= 1.12.8),
     ggplot2 (>= 3.3.2),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ License: GPL-3
 URL: https://docs.ropensci.org/allodb/, https://github.com/ropensci/allodb
 BugReports: https://github.com/ropensci/allodb/issues
 Depends: 
-    R (>= 3.4), 
+    R (>= 3.5), 
     data.table (>= 1.12.8),
     ggplot2 (>= 3.3.2),
     kgc (>= 1.0.0.2),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,7 @@ License: GPL-3
 URL: https://docs.ropensci.org/allodb/, https://github.com/ropensci/allodb
 BugReports: https://github.com/ropensci/allodb/issues
 Depends: 
-    R (>= 3.4444rts: 
+    R (>= 3.4), 
     data.table (>= 1.12.8),
     ggplot2 (>= 3.3.2),
     kgc (>= 1.0.0.2),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,6 +34,7 @@ URL: https://docs.ropensci.org/allodb/, https://github.com/ropensci/allodb
 BugReports: https://github.com/ropensci/allodb/issues
 Depends: 
     R (>= 3.5), 
+Imports:
     data.table (>= 1.12.8),
     ggplot2 (>= 3.3.2),
     kgc (>= 1.0.0.2),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,8 +33,7 @@ License: GPL-3
 URL: https://docs.ropensci.org/allodb/, https://github.com/ropensci/allodb
 BugReports: https://github.com/ropensci/allodb/issues
 Depends: 
-    R (>= 3.6.0)
-Imports: 
+    R (>= 3.4444rts: 
     data.table (>= 1.12.8),
     ggplot2 (>= 3.3.2),
     kgc (>= 1.0.0.2),

--- a/R/resample_agb.R
+++ b/R/resample_agb.R
@@ -104,7 +104,7 @@ resample_agb <- function(genus,
       new_dbh <- paste0("(sampled_dbh * ", dfsub$dbh_unit_cf[j], ")")
       new_equation <- gsub("dbh|DBH", new_dbh, orig_equation)
       agb <-
-        eval(str2lang(new_equation)) * dfsub$output_units_cf[j]
+        eval(parse(text = new_equation)) * dfsub$output_units_cf[j]
     })
   }
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,7 +1,7 @@
 ## Test environments
 
 * ubuntu 18.04 (local), R 4.0.3
-* ubuntu 18.04 (github actions), R 3.5, R-oldrel, R-release, R-devel
+* ubuntu 18.04 (github actions), R 3.5, R 3.6, R-oldrel, R-release, R-devel
 * macOS-latest (github actions), R-release
 * windows-latest (github actions), R 3.6, R-release
 * win-builder, R-release, R-devel


### PR DESCRIPTION
Closes #194 

This PR expands R versions back to R 3.5.
Along the way I update the GitHub Actions
workflow to the latest in 
https://github.com/r-lib/actions/tree/master/examples
via `usethis::use_github_action_check_full()`.
