### PR TITLE
Restore Krista's ORCID

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,8 @@ Authors@R: c(
     person("Camille", "Piponiot", , "camille.piponiot@gmail.com", role = "aut"),
     person("Mauro", "Lepore", , "maurolepore@gmail.com", role = "aut",
            comment = c(ORCID = "0000-0002-1986-7988")),
-    person("Kristina", "Anderson-Teixeira", , "TeixeiraK@si.edu", role = "aut"),
+    person("Kristina", "Anderson-Teixeira", , "TeixeiraK@si.edu", role = "aut",
+           comment = c(ORCID = "0000-0001-8461-9713")),
     person("Jeffrey", "Hanson", , "jeffrey.hanson@uqconnect.edu.au", role = "rev"),
     person("Jonas", "Stillhard", , "jonas.stillhard@wsl.ch", role = "rev")
   )


### PR DESCRIPTION
Closes #205

This commit restores Krista's ORCID.

I messed up and unintentionally removed Krista's ORCID in
c81d6d7dfa8ce9e54a3853950305b4601d651e78

Sorry.
