### PR TITLE
Remove the specific version number of our dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,8 +19,8 @@ BugReports: https://github.com/ropensci/allodb/issues
 Depends: 
     R (>= 3.5) 
 Imports:
+    data.table,
     ggplot2,
-    data.table (>= 1.12.8),
     tibble,
     withr
 Suggests: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,8 +19,8 @@ BugReports: https://github.com/ropensci/allodb/issues
 Depends: 
     R (>= 3.5) 
 Imports:
+    ggplot2,
     data.table (>= 1.12.8),
-    ggplot2 (>= 3.3.2),
     tibble,
     withr
 Suggests: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,6 +24,7 @@ Imports:
     tibble,
     withr
 Suggests: 
+    knitr,
     covr,
     rmarkdown,
     spelling,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,8 +24,7 @@ Imports:
     tibble,
     withr
 Suggests: 
-    covr (>= 3.2.1),
-    knitr (>= 1.21),
+    covr,
     rmarkdown,
     spelling,
     testthat (>= 3.0.0),


### PR DESCRIPTION
Closes #196 

This PR cleans dependencies in DESCRIPTION, by relaxing the version 
number we ask for, and removing some that seem not crucial. I suspect
some of the info is not necessary and we even forgot why it's there (at
least that's the case for the ones I introduced a while ago). So I prefer to
bite the bullet now and clean this up. We can add stuff again but on the
base of need.

I think part of the problem is that adding specific versions used to be
encouraged (by the tidyverse team) so I used to do it. But that is no
longer the case.

- Relax requirement for specific version of ggplot2
- Relax requirement for data.table version
- Relax version of covr and remove knitr

--

@cpiponiot, the two commits below introduced specific versions for ggplot2
and data.table. Do  you remember why? Do you think we could remove the
specific version? 

(If we really need that can then revert the relevant commit in this PR where I 
removed the specific version.)

```
commit 567043a
Author: Camille Piponiot <camille.piponiot@gmail.com>
Date:   Wed Jan 13 11:08:30 2021 +0100

    added the function illustrate_allodb to the package
```

...

```
commit d853412
Author: Camille Piponiot <camille.piponiot@gmail.com>
Date:   Mon Apr 13 15:55:03 2020 -0500

    included the data.table package in the dependencies
```
