### PR TITLE
Increment version number to 0.0.1.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: allodb
 Title: Tree Biomass Estimation at Extra-Tropical Forest Plots
-Version: 0.0.1
+Version: 0.0.1.9000
 Authors@R: c(
     person("Erika", "Gonzalez-Akre", , "GonzalezEB@si.edu", role = c("aut", "cre", "cph"), comment = c(ORCID = "0000-0001-8305-6672")),
     person("Camille", "Piponiot", , "camille.piponiot@gmail.com", role = "aut", comment = c(ORCID = "0000-0002-3473-1982")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# allodb (development version)
+
 # allodb 0.0.1
 
 * Add support for R 3.4.


### PR DESCRIPTION
I forgot to use the development version before. I
should have done it immediately after the first
release on rOpenSci.

It's common practice to end the version number
with .9000 to flag the package is in development.
The only versions that get x.y.z and not x.y.z.9000
are those that correspond exactly to an official
release. Usually that's a CRAN release but here we
consider 0.0.1 the first release on rOpenSci.
