### PR TITLE
updates get_biomass.R for issue #235

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,4 +40,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.3.2

--- a/R/get_biomass.R
+++ b/R/get_biomass.R
@@ -35,8 +35,8 @@
 #' @param genus a character vector (same length as dbh), containing the genus
 #'   (e.g. "Quercus") of each tree.
 #' @param coords a numeric vector of length 2 with longitude and latitude (if
-#'   all trees were measured in the same location) or a matrix with 2 numerical
-#'   columns giving the coordinates of each tree.
+#'   all trees were measured in the same location) or a matrix or data frame with 2 numerical
+#'   columns in the order longitude, latitude giving the coordinates of each tree.
 #' @param species a character vector (same length as dbh), containing the
 #'   species (e.g. "rubra")  of each tree. Default is `NULL`, when no species
 #'   identification is available.
@@ -96,6 +96,9 @@ get_biomass <- function(dbh,
     coords <- matrix(coords, ncol = 2)
   }
   colnames(coords) <- c("long", "lat")
+  # works for list, data.frame, and matrix
+  long_c <- unlist(c(coords[,"long"]))
+  lat_c <- unlist(c(coords[,"lat"]))
 
   ## input data checks
   if (any(!is.na(dbh) & (dbh < 0 | dbh > 1e3))) {
@@ -104,7 +107,7 @@ get_biomass <- function(dbh,
       i = "Do you need to check your data?"
     ))
   }
-  if (any(abs(coords[, 1]) > 180 | abs(coords[, 2]) > 90)) {
+  if (any(abs(long_c) > 180 | abs(lat_c) > 90)) {
     abort(c(
       "`coords` longitudes must range -180 to 180, and latitudes -90 to 90.",
       i = "Do you need to check your data?"
@@ -128,8 +131,8 @@ get_biomass <- function(dbh,
       dbh,
       genus,
       species,
-      long = coords[[1]],
-      lat = coords[[2]]
+      long = long_c,
+      lat = lat_c
     )
     df <-
       merge(

--- a/man/get_biomass.Rd
+++ b/man/get_biomass.Rd
@@ -23,8 +23,8 @@ measurements, in cm.}
 (e.g. "Quercus") of each tree.}
 
 \item{coords}{a numeric vector of length 2 with longitude and latitude (if
-all trees were measured in the same location) or a matrix with 2 numerical
-columns giving the coordinates of each tree.}
+all trees were measured in the same location) or a matrix or data frame with 2 numerical
+columns in the order longitude, latitude giving the coordinates of each tree.}
 
 \item{species}{a character vector (same length as dbh), containing the
 species (e.g. "rubra")  of each tree. Default is \code{NULL}, when no species


### PR DESCRIPTION
updates get_biomass.R for issue #235 to allow for vector, data frame, or matrix to be passed to the `coords` parameter

## Description
The documentation states that the `coords` parameter should be:
>a numeric vector of length 2 with longitude and latitude...or a matrix with 2 numerical columns giving the coordinates of each tree.

However, passing a matrix to the `coords` parameter with >1 rows is not supported due to the handling at these lines:
https://github.com/ropensci/allodb/blob/4207f8616411233f954779789c688433250e651b/R/get_biomass.R#L131-L132

This pull request updates get_biomass.R to allow for a vector, data frame, or matrix to be passed to the `coords` parameter.

## Related Issue
fixes the original issue posed by @ValentineHerr in #235

## Example

```r
dat <- scbi_stem1[1:100, ]
dat$long <- c(rep(-78, 50), rep(-80, 50))
dat$lat <- c(rep(40, 50), rep(41, 50))
# coords data frame
coords_df <- dat[, c("long", "lat")]
# coords matrix
coords_matrix <- as.matrix(coords_df)
# coords vector list
coords_vect <- c(-78,40)
# get_biomass data frame
bm_df <- get_biomass(
  dbh = dat$dbh,
  genus = dat$genus,
  species = dat$species,
  coords = coords_df
)
# get_biomass matrix
bm_matrix <- get_biomass(
  dbh = dat$dbh,
  genus = dat$genus,
  species = dat$species,
  coords = coords_matrix
)
# get_biomass vector list
bm_vect <- get_biomass(
  dbh = dat$dbh,
  genus = dat$genus,
  species = dat$species,
  coords = coords_vect
)
# check
identical(bm_df, bm_matrix, bm_vect)
```
